### PR TITLE
fix: add service initialisation to implement config

### DIFF
--- a/internal/service/config_service.go
+++ b/internal/service/config_service.go
@@ -17,8 +17,12 @@ func ImplementConfig(c *config.Config) error {
 			Exec: &execx.ExecCommander{},
 		},
 		FileDeploySvc:     &FileDeploySvc{},
-		ImageBuildService: &ImageBuildSvc{},
-		InstallerService:  &InstallerSvc{},
+		ImageBuildService: &ImageBuildSvc{
+			Exec: &execx.ExecCommander{},
+		},
+		InstallerService:  &InstallerSvc{
+			Exec: &execx.ExecCommander{},
+		},
 	}
 
 	for _, i := range c.Installers {


### PR DESCRIPTION
## What
Add Exec initialization for ImageBuild and Installer services

## Why
Services with nil execs cause nil pointer deferences

## Scope
- InstallerSvc and ImageBuildSvc
