### PR TITLE
fix: fix build command by listing the argv

### DIFF
--- a/internal/config/image.go
+++ b/internal/config/image.go
@@ -1,7 +1,6 @@
 package config
 
 import (
-	"fmt"
 	"strings"
 )
 
@@ -43,14 +42,13 @@ func (i *Image) Args() []string {
 	}
 
 	if len(i.Tags) > 0 {
-		tagString := []string{"--tags"}
+		args = append(args, "--tags")
 		for _, tag := range i.Tags {
 			parts := strings.SplitSeq(tag, ":")
 			for part := range parts {
-				tagString = append(tagString, fmt.Sprintf(`"%s"`, part))
+				args = append(args, part)
 			}
 		}
-		args = append(args, strings.Join(tagString, " "))
 	}
 
 	return args

--- a/internal/service/image_build_service_test.go
+++ b/internal/service/image_build_service_test.go
@@ -26,13 +26,13 @@ func TestImageBuild(t *testing.T) {
 		Description:             "test3",
 		EnableDynamicAppCatalog: true,
 		UseLatestAgentVersion:   true,
-		Tags:                    []string{"k1", "v1"},
+		Tags:                    []string{"k1", "v1", "k2", "built with appstreamfile"},
 		DryRun:                  true,
 	}
 
 	i.BuildImage(image)
 
-	expectedCommand := strings.TrimSpace(`image-assistant create-image --name "test" --display-name "test2" --description "test3" --use-latest-agent-version --enable-dynamic-app-catalog --dry-run --tags "k1" "v1"`)
+	expectedCommand := strings.TrimSpace(`image-assistant create-image --name test --display-name test2 --description test3 --use-latest-agent-version --enable-dynamic-app-catalog --dry-run --tags k1 v1 k2 built with appstreamfile`)
 	actual := strings.TrimSpace(fmt.Sprintf("%s %s", fc.LastCommand, strings.Join(fc.LastArgs, " ")))
 
 	if expectedCommand != actual {


### PR DESCRIPTION
## What
Fix image-create command with argv listed instead of text formatting, as image-create expectes arguments list rather than text input

## Why
image-create command breaks as go exec passes texts combined text to the image-assistant command

## How
- Added argument value as a separate entry in the arguments slice

## Scope
- image creation

## Test
- Unit tests
- Manual run against a image builder

## Risk
Low. New code path behind flag.
