### PR TITLE
fix: add context to s3client, filedeploy & installer service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 bin
 # Added by goreleaser init:
 dist/
+.DS_Store

--- a/cmd/appstreamfile/main.go
+++ b/cmd/appstreamfile/main.go
@@ -63,7 +63,7 @@ func run(ctx context.Context, opts *RunOptions) error {
 		if opts.bucket == "" || opts.key == "" {
 			return fmt.Errorf("missing required S3 options: bucket and key")
 		}
-		backendSource, err = backend.NewS3Backend(opts.bucket, opts.key, opts.versionId, "appstream_machine_role")
+		backendSource, err = backend.NewS3Backend(ctx, opts.bucket, opts.key, opts.versionId, "appstream_machine_role")
 
 	default:
 		return fmt.Errorf("invalid source provided")

--- a/internal/backend/s3.go
+++ b/internal/backend/s3.go
@@ -50,8 +50,8 @@ func (s3Backend *S3Backend) GetConfig(ctx context.Context) (*config.Config, erro
 	return &configData, nil
 }
 
-func NewS3Backend(bucket, key, versionId, profile string) (BackendSource, error) {
-	client, err := NewS3Client(profile)
+func NewS3Backend(ctx context.Context, bucket, key, versionId, profile string) (BackendSource, error) {
+	client, err := NewS3Client(ctx, profile)
 
 	if err != nil {
 		return nil, fmt.Errorf("not able to create s3 client: %w", err)

--- a/internal/backend/s3_client.go
+++ b/internal/backend/s3_client.go
@@ -29,14 +29,12 @@ func (c *S3BackendClient) GetObject(ctx context.Context, bucket string, key stri
 	return c.s3Client.GetObject(ctx, objectInput)
 }
 
-func NewS3Client(profile string) (S3Client, error) {
+func NewS3Client(ctx context.Context, profile string) (S3Client, error) {
 	opts := []func(*s3Config.LoadOptions) error{}
 
 	if profile != "" {
 		opts = append(opts, s3Config.WithSharedConfigProfile(profile))
 	}
-
-	ctx := context.Background()
 
 	cfg, err := s3Config.LoadDefaultConfig(ctx, opts...)
 	if err != nil {

--- a/internal/service/config_service.go
+++ b/internal/service/config_service.go
@@ -32,7 +32,7 @@ func ImplementConfig(ctx context.Context, c *config.Config) error {
 
 	for _, f := range c.Files {
 		fmt.Println("Deploying file", f.Path)
-		err := services.FileDeploySvc.DeployFile(&f)
+		err := services.FileDeploySvc.DeployFile(ctx, &f)
 
 		if err != nil {
 			return fmt.Errorf("error deploying file %s: %w", f.Path, err)

--- a/internal/service/file_deploy_service.go
+++ b/internal/service/file_deploy_service.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -12,7 +13,12 @@ import (
 type FileDeploySvc struct {
 }
 
-func (s *FileDeploySvc) DeployFile(f *config.File) error {
+func (s *FileDeploySvc) DeployFile(ctx context.Context, f *config.File) error {
+
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	if err := os.MkdirAll(filepath.Dir(f.Path), 0770); err != nil {
 		return fmt.Errorf("error creating required directories for %s: %w", f.Path, err)
 	}

--- a/internal/service/file_deploy_service_test.go
+++ b/internal/service/file_deploy_service_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"context"
 	"os"
 	"testing"
 
@@ -8,6 +9,8 @@ import (
 )
 
 func TestFileDeploy(t *testing.T) {
+	ctx := context.TODO()
+
 	file, err := os.CreateTemp("../../testdata", "test.txt")
 	defer func() {
 		os.Remove(file.Name())
@@ -24,7 +27,7 @@ func TestFileDeploy(t *testing.T) {
 
 	s := FileDeploySvc{}
 
-	s.DeployFile(f)
+	s.DeployFile(ctx, f)
 
 	content, err := os.ReadFile(f.Path)
 

--- a/internal/service/installer_service.go
+++ b/internal/service/installer_service.go
@@ -15,6 +15,10 @@ type InstallerSvc struct {
 }
 
 func (s *InstallerSvc) InstallScript(ctx context.Context, inst *config.Installer) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
 	var (
 		exe  string
 		ext  string


### PR DESCRIPTION
  Overview
  This PR improves context propagation across the application, specifically updating the S3 client initialization and file deployment/installer services to accept and respect
  context.Context.

  Changes
   - S3 Client: Updated NewS3Backend and NewS3Client to accept context.Context as an argument instead of creating a new context.Background() internally. This ensures the
     application context (and any associated timeouts/cancellations) is correctly passed to the AWS SDK loader.
   - File Deploy Service: Updated DeployFile to accept context.Context and added a check for ctx.Err() to support early cancellation.
   - Installer Service: Added a check for ctx.Err() in InstallScript to support early cancellation.
   - Tests & Call Sites: Updated main.go, config_service.go and relevant tests to match the new function signatures.

  Motivation
  Ensures that the application can gracefully handle cancellations and timeouts, especially during backend initialization and file deployment operations.

  Checklist
   - [x] Code compiles and runs
   - [x] Tests updated and passing